### PR TITLE
Check connection race condition (goroutine leak) and pong problem

### DIFF
--- a/websocket_client.go
+++ b/websocket_client.go
@@ -106,8 +106,8 @@ func (ws *WebsocketClient) Listen() {
 
 func (ws *WebsocketClient) checkConnection(done <-chan struct{}) {
 	var timer *time.Timer
-	pingInterval := 5 * time.Second
-	pongWait := 4 * time.Second // less than pingInterval
+	pingInterval := 10 * time.Second
+	pongWait := 9 * time.Second // less than pingInterval
 	for {
 		ws.Conn.SetReadDeadline(time.Now().Add(pongWait))
 		if err := ws.writeMessage(websocket.PingMessage, []byte("PING")); err != nil {

--- a/websocket_client.go
+++ b/websocket_client.go
@@ -111,7 +111,8 @@ func (ws *WebsocketClient) checkConnection(done <-chan struct{}) {
 	for {
 		ws.Conn.SetReadDeadline(time.Now().Add(pongWait))
 		if err := ws.writeMessage(websocket.PingMessage, []byte("PING")); err != nil {
-			log.Printf("[ERROR][WS] Sending ping: %v", err)
+			ws.Conn.SetReadDeadline(time.Time{})
+			log.Println("[ERROR][WS] Sending ping:", err)
 			return
 		}
 		if timer == nil {

--- a/websocket_client.go
+++ b/websocket_client.go
@@ -62,7 +62,7 @@ func (ws *WebsocketClient) Listen() {
 	if ws.Conn == nil {
 		ws.Connect()
 	}
-	pongWait := 6 * time.Second
+	pongWait := 10 * time.Second
 	ws.Conn.SetReadDeadline(time.Now().Add(pongWait))
 	ws.Conn.SetPongHandler(func(string) error {
 		ws.Conn.SetReadDeadline(time.Now().Add(pongWait))

--- a/websocket_client.go
+++ b/websocket_client.go
@@ -80,7 +80,7 @@ func (ws *WebsocketClient) Listen() {
 	if ws.Conn == nil {
 		ws.Connect()
 	}
-	var checkConnDone = make(chan struct{})
+	checkConnDone := make(chan struct{})
 	ws.Conn.SetPongHandler(func(string) error {
 		ws.Conn.SetReadDeadline(time.Time{})
 		return nil

--- a/websocket_client.go
+++ b/websocket_client.go
@@ -107,7 +107,7 @@ func (ws *WebsocketClient) Listen() {
 func (ws *WebsocketClient) checkConnection(done <-chan struct{}) {
 	var timer *time.Timer
 	pingInterval := 5 * time.Second
-	pongWait := 5 * time.Second
+	pongWait := 4 * time.Second // less than pingInterval
 	for {
 		ws.Conn.SetReadDeadline(time.Now().Add(pongWait))
 		if err := ws.writeMessage(websocket.PingMessage, []byte("PING")); err != nil {


### PR DESCRIPTION
Fixed:
1. Goroutine leaks.
2. Panic while concurrent writing.
3. Changed ping/pong control. Measure ping/pong interval instead of pong/pong one.
4. Increased ping/pong interval to 9 seconds. The interval was equal to 8.097564857s at 2018-06-22 13:58:41.320568127 +0300 MSK in Cybo project (to Naga).
