### PR TITLE
panic: runtime error: invalid memory address or nil pointer dereference

### DIFF
--- a/websocket_client.go
+++ b/websocket_client.go
@@ -55,10 +55,10 @@ func (ws *WebsocketClient) Connect() error {
 	log.Printf("[INFO] Connecting to %s", url)
 
 	c, _, err := websocket.DefaultDialer.Dial(url, nil)
-	ws.Conn = c
 	if err != nil {
 		return err
 	}
+	ws.Conn = c // c is nil if error. Do not move above because of concurrent goroutines.
 	ws.initData.Do(func() {
 		ws.writeChan = make(chan writingMessage)
 		ws.writeErrChan = make(chan error)


### PR DESCRIPTION
While reconnect error: "panic: runtime error: invalid memory address or nil pointer dereference".

Jun 27 05:19:14 de2 tp-orders[958]: panic: runtime error: invalid memory address or nil pointer dereference
Jun 27 05:19:14 de2 tp-orders[958]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x623647]
Jun 27 05:19:14 de2 tp-orders[958]: goroutine 626 [running]:
Jun 27 05:19:14 de2 tp-orders[958]: github.com/gorilla/websocket.(*Conn).WriteMessage(0x0, 0x1, 0xc4209edb00, 0x90, 0x109, 0x0, 0x0)